### PR TITLE
append '.css' at the end of name if not specified by the user.

### DIFF
--- a/config/gulpfile.js
+++ b/config/gulpfile.js
@@ -67,7 +67,7 @@ const styles = done => {
             gulp.src(scss.src)
                 .pipe(plugins.sass())
                 .pipe(plugins.if(isProd, plugins.cleanCss()))
-                .pipe(plugins.concat(scss.name))
+                .pipe(plugins.concat(scss.name.endsWith(".css") ? scss.name : `${scss.name}.css`))
                 .pipe(gulp.dest(paths.dist + '/css'))
                 .on('end', function () {
                     if ((--count === 0) && !isDone) {


### PR DESCRIPTION
**What does this PR do?**
Adds .css extension automatically to generated files if not specified by the user in scss_bundles.

**Where to start reviewing?**
gulpfile.js

**Related Issues?**
n/a

**Caveats?**
N/A

**Reviewers?**
@nkrusch 