### PR TITLE
make release filename customizable

### DIFF
--- a/config/build.json
+++ b/config/build.json
@@ -3,6 +3,7 @@
   "dist": "./dist",
   "source": "./src",
   "releases": "./",
+  "release_name": "release",
   "manifest": "./src/manifest.json",
   "js": "./src/**/*.js",
   "js_bundles": null,

--- a/config/gulpfile.js
+++ b/config/gulpfile.js
@@ -83,7 +83,7 @@ const copyAs = done => {
 
     const _filesToCopy = (Array.isArray(paths.copyAsIs) ?
         paths.copyAsIs : [paths.copyAsIs]);
-    
+
     let copyList = [..._filesToCopy];
 
     const doCopy = (src, callback) => {
@@ -176,7 +176,9 @@ const custom_commands = done => {
 const release = done => {
     return isProd ?
         gulp.src(paths.dist + '/**/*')
-            .pipe(plugins.zip('release.zip'))
+            .pipe(plugins.zip(
+                `${paths.release_name || 'release'}.zip`
+            ))
             .pipe(gulp.dest(paths.releases))
             .on('end', done) :
         done();

--- a/guide/03-xt-build.md
+++ b/guide/03-xt-build.md
@@ -92,6 +92,7 @@ The CLI uses a default build configuration file shown below. This tells the exte
   "dist": "./dist",
   "source": "./src",
   "releases": "./",
+  "release_name": "release",
   "manifest": "./src/manifest.json",
   "js": "./src/**/*.js",
   "js_bundles": null,


### PR DESCRIPTION
This change makes the release filename customizable by the client. Release name should be specified without file extension.

I ran into needing this in a project using a CI + multiple target releases for different browsers. I wanted to be able to upload those releases to Github, but they will have the same filename until I can override the release filename.

**Current behavior**
At the moment it is hardcoded and no option to override. 

**Regression**
This change is backwards compatible and will fallback to `release.zip` if client does not specify a custom name for the release zip file. 