### PR TITLE
Platform specific properties in manifest and copy assets folder

### DIFF
--- a/cli/xt-build.js
+++ b/cli/xt-build.js
@@ -24,17 +24,19 @@ const Spinner = require('cli-spinner').Spinner;
 const exec = require('child_process').exec;
 const pkg = require('../package.json');
 const env = {prod: 'prod', dev: 'dev'};
+const platform = {chrome: 'chrome', firefox: 'firefox'};
 const texts = require('../config/texts').xtBuild;
 const gulpfile = path.resolve(__dirname, '../config/gulpfile.js');
 
 program
     .version(pkg.version)
     .option('-e --env <env>', texts.envArg, /^(dev|prod)$/i, env.prod)
+    .option('-p <platform>', texts.platformArg, /^(chrome|firefox)$/i, platform.chrome)
     .option('-c --config <config>', texts.configFileArg, /^(.*)$/i)
     .option('-w --watch', texts.watchArg)
     .parse(process.argv);
 
-const {watch, env: programEnv, config} = program.opts();
+const {watch, env: programEnv, config, p: platformEnv} = program.opts();
 
 const args = [
     watch ? 'gulp watch' : 'gulp',
@@ -42,6 +44,7 @@ const args = [
     util.format('--config "%s"', path.resolve(process.cwd(), config || './.xtbuild.json')),
     util.format('--pkg', path.resolve(process.cwd(), './package.json')),
     util.format('--%s', programEnv),
+    util.format('--%s', platformEnv),
     '--colors'
 ].join(' ');
 

--- a/config/build.json
+++ b/config/build.json
@@ -10,11 +10,10 @@
   "html": "./src/**/*.html",
   "scss": "./src/**/*.scss",
   "scss_bundles": null,
-  "icons": [
-    "./assets/img/**/*.png",
-    "./assets/img/**/*.gif",
-    "./assets/img/**/*.jpg",
-    "./assets/img/**/*.svg"
+  "assets": [
+    "./assets/**/*",
+    "!./assets/locales",
+    "!./assets/locales/**/*"
   ],
   "copyAsIs": [],
   "locales_dir": "./assets/locales/",

--- a/config/init/package.json
+++ b/config/init/package.json
@@ -10,7 +10,9 @@
   },
   "scripts": {
     "start": "xt-build -e dev -w",
+    "start:firefox": "xt-build -e dev -p firefox -w",
     "build": "xt-build -e prod",
+    "build:firefox": "xt-build -e prod -p firefox",
     "clean": "xt-clean",
     "docs": "xt-docs",
     "test": "xt-test",

--- a/config/texts.js
+++ b/config/texts.js
@@ -146,6 +146,8 @@ exports.xtBuild = {
 
     watchArg: 'Enable watch',
 
+    platformArg: 'Platform',
+
     configFileArg: 'Path to configuration file, default: .xtbuild.json in root, or xtbuild in package.json)',
 
     onBuildSuccess: _ => (

--- a/package-lock.json
+++ b/package-lock.json
@@ -3614,6 +3614,20 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
+    "event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "requires": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "eventemitter2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
@@ -4111,6 +4125,11 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "from2": {
       "version": "2.3.0",
@@ -5126,6 +5145,14 @@
         "gulp-cli": "^2.2.0",
         "undertaker": "^1.2.1",
         "vinyl-fs": "^3.0.0"
+      }
+    },
+    "gulp-change": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-change/-/gulp-change-1.0.2.tgz",
+      "integrity": "sha512-Okikw3E9bK+mmhC8VGFk+i4iafKTtGTnTGpCheuGtJn51TuMxQ5ooLeRvAfncyr4FQF+Byksj9OaecpDpYDFkw==",
+      "requires": {
+        "event-stream": "^4.0.1"
       }
     },
     "gulp-clean-css": {
@@ -6924,6 +6951,11 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
+    "map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -8308,6 +8340,14 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "~2.3"
+      }
+    },
     "pbkdf2": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
@@ -9686,6 +9726,14 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -9776,6 +9824,15 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "stream-each": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "foodoc": "^0.0.9",
     "globby": "^11.0.3",
     "gulp": "^4.0.2",
+    "gulp-change": "^1.0.2",
     "gulp-clean-css": "^4.3.0",
     "gulp-concat": "^2.6.1",
     "gulp-htmlmin": "^5.0.1",


### PR DESCRIPTION
What does this PR do?

1. Add platform specific properties to manifest. Now you can use `chrome` and `firefox` to define browser specific properties in manifest. Please note that `chrome` is used as default configuration. 
2. Copies whole assets folder to build dir except locales as they are processed separately. 


Where to start reviewing?
gulpfile.js

Related Issues?
n/a

Caveats?
Builds file in same folder irrespective of build config. This can be an issue for parallel testing in Firefox and Chrome.

Reviewers?
@nkrusch