### PR TITLE
Custom folders for scss bundles and always minify css.

### DIFF
--- a/config/gulpfile.js
+++ b/config/gulpfile.js
@@ -75,12 +75,15 @@ const styles = done => {
         isDone = false;
 
     return !count ? done() :
-        bundles.map(scss => {
-            gulp.src(scss.src)
+        bundles.map(b => {
+            gulp.src(b.src)
                 .pipe(plugins.sass())
-                .pipe(plugins.if(isProd, plugins.cleanCss()))
-                .pipe(plugins.concat(scss.name.endsWith(".css") ? scss.name : `${scss.name}.css`))
-                .pipe(gulp.dest(paths.dist + '/css'))
+                .pipe(plugins.cleanCss())
+                .pipe(plugins.rename(function (path) {
+                    path.dirname = '';
+                    path.basename = b.name;
+                }))
+                .pipe(gulp.dest(paths.dist))
                 .on('end', function () {
                     if ((--count === 0) && !isDone) {
                         isDone = true;


### PR DESCRIPTION
What does this PR do?
SCSS bundles can be compiled to custom location define by the user same as JS bundles. I've removed production check from cleanCSS because I didn't found any solid reason to do so. Please let me know if you have any use case for it.

Where to start reviewing?
gulpfile.js

Related Issues?
n/a

Caveats?
Older projects will have update there package.json so that bundles can be compiled to `dist/css`

Reviewers?
@nkrusch