### PR TITLE
fix: default style bundle without file extension

### DIFF
--- a/config/gulpfile.js
+++ b/config/gulpfile.js
@@ -76,7 +76,7 @@ const scripts = done => {
 
 const styles = done => {
     let bundles = Array.isArray(paths.scss_bundles) ?
-        paths.scss_bundles : [{src: paths.scss, name: 'styles.css'}],
+        paths.scss_bundles : [{src: paths.scss, name: 'styles'}],
         count = bundles.length,
         isDone = false;
 


### PR DESCRIPTION
Minor fix: building styles without custom config duplicates extension `.css.css`. This fix will change it to `.css`.