### PR TITLE
change webpack devtool to cheap-source-map

### DIFF
--- a/config/gulpfile.js
+++ b/config/gulpfile.js
@@ -40,7 +40,7 @@ const scripts = done => {
     let bundles = [..._bundles];
     const webpackOptions = {
         mode: isProd ? "production" : "development",
-        devtool: 'source-map'
+        devtool: 'cheap-source-map'
     };
 
     const buildScript = () => {


### PR DESCRIPTION
What does this PR do?
Changes webpack devtool to more performant `cheap-source-map`. This will help speed up compilation a bit although we should consider giving user an option to add custom webpack config. Lower config systems should benefit from this.  

Where to start reviewing?
gulpfile.js

Related Issues?
n/a

Caveats?
n/a

Reviewers?
@nkrusch