### PR TITLE
Remove devtool from production build

### DIFF
--- a/config/gulpfile.js
+++ b/config/gulpfile.js
@@ -38,10 +38,8 @@ const scripts = done => {
     const _bundles = (Array.isArray(paths.js_bundles) ? paths.js_bundles : [paths.js_bundles]);
 
     let bundles = [..._bundles];
-    const webpackOptions = {
-        mode: isProd ? "production" : "development",
-        devtool: 'cheap-source-map'
-    };
+    const webpackOptions = { mode: isProd ? "production" : "development" };
+    if (!isProd) webpackOptions.devtool = "cheap-source-map";
 
     const buildScript = () => {
         if (!bundles.length) {


### PR DESCRIPTION
What does this PR do?
Devtool property is removed from production build so that source maps are not generated.

Where to start reviewing?
gulpfile.js

Related Issues?
n/a

Caveats?
n/a

Reviewers?
@nkrusch