### PR TITLE
set mode to development and devtool to none in production build

### DIFF
--- a/config/gulpfile.js
+++ b/config/gulpfile.js
@@ -38,8 +38,9 @@ const scripts = done => {
     const _bundles = (Array.isArray(paths.js_bundles) ? paths.js_bundles : [paths.js_bundles]);
 
     let bundles = [..._bundles];
-    const webpackOptions = { mode: isProd ? "production" : "development" };
+    const webpackOptions = { mode: "development" };
     if (!isProd) webpackOptions.devtool = "cheap-source-map";
+    else webpackOptions.devtool = "none";
 
     const buildScript = () => {
         if (!bundles.length) {


### PR DESCRIPTION
What does this PR do?
Permanently set mode to development irrespective to build mode and set devtool to 'none' in production mode

Where to start reviewing?
gulpfile.js

Related Issues?
n/a

Caveats?
n/a

Reviewers?
@nkrusch