### PR TITLE
Change command to prompt with options

### DIFF
--- a/config/init/package.json
+++ b/config/init/package.json
@@ -16,7 +16,7 @@
     "clean": "xt-clean",
     "docs": "xt-docs",
     "test": "xt-test",
-    "sync": "xt-sync --all"
+    "sync": "xt-sync"
   },
   "babel": {
     "presets": [

--- a/config/texts.js
+++ b/config/texts.js
@@ -55,20 +55,15 @@ exports.xtCreate = {
  */
 exports.xtSync = {
 
-    argGitlab: 'sync gitlab-ci.yml',
+    argGitlab: 'gitlab CI config',
 
-    argTravis: 'sync travis.yml',
+    argTravis: 'travis CI config',
 
-    argLint: 'sync eslint',
+    argLint: 'eslint config',
 
-    argGitIgnore: 'sync gitignore',
+    argGitIgnore: 'gitignore',
 
-    argAll: 'sync everything',
-
-    onError: (
-        chalk.red('Specify which files to sync using flags.\n' +
-            'See --help for more details.')
-    ),
+    instructions: 'choose the files you want to sync:',
 
     updateSuccess: (what) => (
         chalk.bold.green(`✓ updated ${what}`)

--- a/guide/06-xt-sync.md
+++ b/guide/06-xt-sync.md
@@ -3,76 +3,53 @@
 
 * * *
 
-<p class='page-intro'><code>xt-sync</code> command is intended for upgrading configuration files of
-a stale project to the latest versions</p>
+<p class='page-intro'><code>xt-sync</code> is intended for copying and updating 
+configuration files.</p>
 
 * * *
 
-When a project has not been worked on recently, it may need updates of 
-various files, such as CI configuration files. 
+When adding more features to an extension project, it may be helpful
+to not start from scratch. `xt-sync` command enables extension projects
+to pull in starter configuration files for the purposes of linting, 
+setting up automated CI builds, and for setting up git VCS.
 
-The purpose of this command is to make that update process simple by
-allowing each project to choose which configuration files to update.
-The CLI will then supply the project with the most recent configuration
-files.
+The configuration files are intended as a starting point. If you
+end up modifying them heavily at a project level, you should continue
+to maintain them manually instead of using this command.
 
-**Note:** If the configuration files have been modified heavily for 
-an individual project, it is not advisable to upgrade them in this manner. 
-Instead you should upgrade such configuration files manually.
+If you do not modify these configuration files, you can sync the 
+latest version periodically, to update to the latest version supplied
+by this CLI.
 
 ## Commands
 
-Braces `{ }` indicate that the user must choose one (and only one) of the items inside the braces.
+**Sync configuration files**
 
-You must pass at least one flag with this command.
-
-
-**Synchronize all configuration files**
+This command will guide you through the available options. 
 
 ```bash
-xt-sync {-a|--all}
+xt-sync
 ```
 
-**Synchronize ESLint configuration file**
-
-```bash
-xt-sync {-e|--eslint}
-```
-
-**Synchronize Gitlab CI configuration file**
-
-```bash
-xt-sync {-l|--gitlab}
-```
-
-**Synchronize Travis CI configuration file**
-
-```bash
-xt-sync {-t|--travis}
-``` 
-
-**Synchronize .gitignore file**
-
-```bash
-xt-sync {-g|--gitignore}
-``` 
-
-**Get help using this command**
-
-```bash
-xt-sync --help
-``` 
 
 ## Package.json scripts
 
-After installing extension-cli, you can run these commands from a terminal using `npx xt-sync --all`.
+After installing extension-cli, you can run these commands from a terminal by calling
  
-Or you can add an option to `packages.json` scripts section and then execute the command as `npm run sync`.
-See example below.
+```bash
+npx xt-sync
+```
+
+Alternatively you can add an option to `packages.json` scripts section as shown below
  
 ```json
-"scripts":{
-  "sync": "xt-sync --all"
+"scripts" : {
+  "sync": "xt-sync"
 }
 ```
 
+and then execute the command by running 
+
+```bash
+npm run sync
+```


### PR DESCRIPTION
**summary**

This PR changes the behavior of `xt-sync` to prompt user with options and updates the related docs in user guide. 

Calling the command with previously valid flags will error but running `--help` explains the current behavior and options.
