### PR TITLE
deprecate watch path config key

### DIFF
--- a/cli/gulpfile.js
+++ b/cli/gulpfile.js
@@ -12,7 +12,6 @@ const {prod: isProd, firefox: isFirefox, pkg: pkgPath, config} = argv;
 
 /** helper method to ensure array type */
 const ensureArray = path => Array.isArray(path) ? path : [path];
-const chooseArray = (input, _default) => Array.isArray(input) ? input : _default;
 
 /** read project package.json **/
 const pkg = Utilities.readJSON(pkgPath);
@@ -35,10 +34,6 @@ if (customPaths) {
         }
     }
 }
-
-/** src for scripts and styles; for use later in tasks **/
-const scriptBundles = chooseArray(paths.js_bundles, [{src: paths.js, name: 'script'}]);
-const styleBundles = chooseArray(paths.scss_bundles, [{src: paths.scss, name: 'styles'}])
 
 const clean = () => del([paths.dist + '/*']);
 
@@ -177,10 +172,10 @@ const dynamicFunc = (action, name) => {
     return f;
 }
 
-const scripts = scriptBundles.map(obj =>
+const scripts = paths.js_bundles.map(obj =>
     dynamicFunc(_ => script(obj), `${obj.name}.js`));
 
-const styles = styleBundles.map(obj =>
+const styles = paths.scss_bundles.map(obj =>
     dynamicFunc(_ => style(obj), `${obj.name}.css`));
 
 const locales = paths.locales_list.map(lang =>
@@ -191,10 +186,10 @@ const copies = ensureArray(paths.copyAsIs).map(obj =>
 
 const watch = () => {
     console.log(chalk.bold.yellow('watching...'));
-    scriptBundles.map(({src}, i) => {
+    paths.js_bundles.map(({src}, i) => {
         gulp.watch(ensureArray(src), scripts[i]);
     })
-    styleBundles.map(({src}, i) => {
+    paths.scss_bundles.map(({src}, i) => {
         gulp.watch(ensureArray(src), styles[i]);
     })
     ensureArray(paths.copyAsIs).map((path, i) => {

--- a/config/build.json
+++ b/config/build.json
@@ -5,10 +5,16 @@
   "release_name": "release",
   "manifest": "./src/manifest.json",
   "js": "./src/**/*.js",
-  "js_bundles": null,
+  "js_bundles": [{
+    "src":"./src/**/*.js",
+    "name": "script"
+  }],
   "html": "./src/**/*.html",
   "scss": "./src/**/*.scss",
-  "scss_bundles": null,
+  "scss_bundles": [{
+    "src":"./src/**/*.scss",
+    "name": "styles"
+  }],
   "assets": [
     "./assets/**/*",
     "!./assets/locales",

--- a/guide/03-xt-build.md
+++ b/guide/03-xt-build.md
@@ -105,10 +105,16 @@ Explanations for each of these keys is given below.
   "release_name": "release",
   "manifest": "./src/manifest.json",
   "js": "./src/**/*.js",
-  "js_bundles": null,
+  "js_bundles": [{
+    "src":"./src/**/*.js",
+    "name": "script"
+  }],
   "html": "./src/**/*.html",
   "scss": "./src/**/*.scss",
-  "scss_bundles": null,
+  "scss_bundles": [{
+    "src":"./src/**/*.scss",
+    "name": "styles"
+  }],
   "assets": [
     "./assets/**/*",
     "!./assets/locales",
@@ -133,10 +139,10 @@ Key | Description | Guide
 `"releases"` | Directory for outputting release zip file ||
 `"release_name"` | name of release zip file ||
 `"manifest"` | Extension manifest file with path ||
-`"js"` | Javascript watch pattern during dev builds ||
+`"js"` | **deprecated** - use `js_bundles` ||
 `"js_bundles"` | Javascript bundles configuration | [Guide](03-xt-build-scripts.md)
 `"html"` | location and watch pattern of HTML files ||
-`"scss"` | Stylesheets watch pattern during dev builds ||
+`"scss"` | **deprecated** - use `scss_bundles` ||
 `"scss_bundles"` | Stylesheets bundles configuration | [Guide](03-xt-build-styles.md)
 `"assets"` | Static assets configuration match pattern | [Guide](03-xt-build-assets.md) 
 `"copyAsIs"` | Files and directories to copy without modification | [Guide](03-xt-build-copy.md)

--- a/guide/13-cli-development.md
+++ b/guide/13-cli-development.md
@@ -4,22 +4,19 @@ disqus: "False"
 
 # Extension CLI Development
 
-This CLI is built with numerous tools listed below and written in Javascript. 
-
-The source code is available on [Github](https://github.com/MobileFirstLLC/extension-cli).
-
-Releases are published on [NPM](https://www.npmjs.com/package/extension-cli).
+- This CLI is built with numerous tools listed below and written in JavaScript. 
+- The source code is available on [Github](https://github.com/MobileFirstLLC/extension-cli).
+- Releases are published on [NPM](https://www.npmjs.com/package/extension-cli).
 
 ## Tech Stack
 
-Extension CLI is built with all of the following:
+Extension CLI is built with the following:
 
 [Node.js][0]  [Gulp][1]  [Chalk][2]  [Commander][3]  [Babel][4]  [Chai][5] [Mocha][6]  [ESLint][7]  [jsdom][8]  [JSDoc][9]  [prompts][10]  [Sinon][11] [Sinon-chrome][16]  [NYC][12]  [Webpack][13] [CLI Spinner][14]  [yargs][15]   
 
 This user guide is built with [MkDocs](https://www.mkdocs.org/) and  [MkDocs material theme](https://squidfunk.github.io/mkdocs-material/).
 
-CI builds by [Travis CI](https://travis-ci.org/MobileFirstLLC/extension-cli) and documentation served by Github Pages.
-
+CI builds by [Travis CI](https://travis-ci.org/MobileFirstLLC/extension-cli) and documentation served by [Github Pages](https://pages.github.com/).
 
 ## Project Organization
 
@@ -33,7 +30,6 @@ Path | Description
 └ `/*` | Application root; various project config files
 
 * * *
-
 
 To setup a local dev environment and develop the CLI application, see
  


### PR DESCRIPTION
- use bundle key to build and watch js & css
- use default wildcard as default bundle value
- watch is now by file, so having a separate key is redundant -> updated docs