### PR TITLE
Added sourceMapFilename so sourcemaps point to the correct path

### DIFF
--- a/cli/gulpfile.js
+++ b/cli/gulpfile.js
@@ -44,7 +44,7 @@ const script = ({src, name, mode}, done = _ => true) => {
         // use mode if specified explicitly; otherwise choose by --env
         mode: mode || (isProd ? 'production' : 'development'),
         // match sourcemap name with configured js file name
-        output: {filename: `${name}.js`},
+        output: {filename: `${name}.js`, sourceMapFilename: `${name}.map[query]`},
         // use source map with dev builds only
         devtool: isProd ? undefined : 'cheap-source-map'
     };


### PR DESCRIPTION
While watching with `npm run start`, sourcemaps are generated without the .js extension, but the end of file reference points to the file with the extension, and therefore fails to load.

For example the src file `settings.js` has a generated source map of `settings.map`, and is referenced as `settings.js.map`.